### PR TITLE
Fix tile-based pixel validation

### DIFF
--- a/__tests__/dangerfile.test.js
+++ b/__tests__/dangerfile.test.js
@@ -248,13 +248,23 @@ describe('isValidNewPixelSubmission', () => {
     expect(isValidNewPixelSubmission(pixel, 'dkundel')).toBe(false);
   });
 
-  test('fails if color is missing', () => {
+  test('fails if color and tile name are missing', () => {
     const pixel = {
       username: 'twilio',
       x: 0,
       y: 0
     };
     expect(isValidNewPixelSubmission(pixel, 'dkundel')).toBe(false);
+  });
+
+  test('succeeds for valid tile pixel', () => {
+    const pixel = {
+      username: 'dkundel',
+      tileName: 'cat',
+      y: 0,
+      x: 0
+    };
+    expect(isValidNewPixelSubmission(pixel, 'dkundel')).toBe(true);
   });
 
   test('fails if x coordinate is not a number', () => {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -203,9 +203,9 @@ function isValidNewPixelSubmission(pixel, gitHubUsername) {
     result = false;
   }
 
-  if (!pixel.color) {
+  if (!pixel.color && !pixel.tileName) {
     fail(
-      `Please specify either a color using \`color: '#000000\` in your pixel.`
+      `Please specify either a color using \`color: '#000000'\` or a \`tileName\` in your pixel.`
     );
     result = false;
   }


### PR DESCRIPTION
## Summary
- allow `isValidNewPixelSubmission` to accept tiles (via `tileName`)
- test tile support for new pixel submissions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68538ead6b04832186db526cde529d94